### PR TITLE
Stay alive while queries pending

### DIFF
--- a/examples/dns_parser.rs
+++ b/examples/dns_parser.rs
@@ -50,7 +50,7 @@ fn main() {
         }
     );
 
-    // If we allowed the resolver to be dropped, we'd shut down c-ares and the
-    // query would fail.  Wait for the handler to signal that it is done.
+    // Don't allow the main thread to exit before the query completes - wait
+    // for the handler to signal that it is done.
     rx.recv().expect("query did not complete!");
 }

--- a/examples/futures.rs
+++ b/examples/futures.rs
@@ -1,11 +1,13 @@
 // This example demonstrates use of the `FutureResolver`.
 extern crate c_ares;
 extern crate c_ares_resolver;
+extern crate futures;
 extern crate tokio_core;
 
 use std::error::Error;
 
 use c_ares_resolver::FutureResolver;
+use futures::future::Future;
 
 fn print_mx_results(result: &Result<c_ares::MXResults, c_ares::Error>) {
     match *result {
@@ -27,12 +29,16 @@ fn print_mx_results(result: &Result<c_ares::MXResults, c_ares::Error>) {
 
 fn main() {
     // Create Resolver and make a query.
-    let resolver = FutureResolver::new().expect("Failed to create resolver");
-    let query = resolver.query_mx("gmail.com");
+    let query = {
+        let resolver = FutureResolver::new().expect("Failed to create resolver");
+        resolver.query_mx("gmail.com").then(|result| {
+            print_mx_results(&result);
+            result
+        })
+    };
 
     // Run the query to completion and print the results.
     let mut event_loop = tokio_core::reactor::Core::new()
         .expect("Failed to create event loop");
-    let result = event_loop.run(query);
-    print_mx_results(&result);
+    event_loop.run(query).ok();
 }

--- a/src/blockingresolver.rs
+++ b/src/blockingresolver.rs
@@ -42,26 +42,26 @@ impl BlockingResolver {
     /// String format is `host[:port]`.  IPv6 addresses with ports require
     /// square brackets eg `[2001:4860:4860::8888]:53`.
     pub fn set_servers(
-        &mut self,
-        servers: &[&str]) -> Result<&mut Self, c_ares::Error> {
+        &self,
+        servers: &[&str]) -> Result<&Self, c_ares::Error> {
         self.inner.set_servers(servers)?;
         Ok(self)
     }
 
     /// Set the local IPv4 address from which to make queries.
-    pub fn set_local_ipv4(&mut self, ipv4: &Ipv4Addr) -> &mut Self {
+    pub fn set_local_ipv4(&self, ipv4: &Ipv4Addr) -> &Self {
         self.inner.set_local_ipv4(ipv4);
         self
     }
 
     /// Set the local IPv6 address from which to make queries.
-    pub fn set_local_ipv6(&mut self, ipv6: &Ipv6Addr) -> &mut Self {
+    pub fn set_local_ipv6(&self, ipv6: &Ipv6Addr) -> &Self {
         self.inner.set_local_ipv6(ipv6);
         self
     }
 
     /// Set the local device from which to make queries.
-    pub fn set_local_device(&mut self, device: &str) -> &mut Self {
+    pub fn set_local_device(&self, device: &str) -> &Self {
         self.inner.set_local_device(device);
         self
     }

--- a/src/futureresolver.rs
+++ b/src/futureresolver.rs
@@ -76,26 +76,26 @@ impl FutureResolver {
     /// String format is `host[:port]`.  IPv6 addresses with ports require
     /// square brackets eg `[2001:4860:4860::8888]:53`.
     pub fn set_servers(
-        &mut self,
-        servers: &[&str]) -> Result<&mut Self, c_ares::Error> {
+        &self,
+        servers: &[&str]) -> Result<&Self, c_ares::Error> {
         self.inner.set_servers(servers)?;
         Ok(self)
     }
 
     /// Set the local IPv4 address from which to make queries.
-    pub fn set_local_ipv4(&mut self, ipv4: &Ipv4Addr) -> &mut Self {
+    pub fn set_local_ipv4(&self, ipv4: &Ipv4Addr) -> &Self {
         self.inner.set_local_ipv4(ipv4);
         self
     }
 
     /// Set the local IPv6 address from which to make queries.
-    pub fn set_local_ipv6(&mut self, ipv6: &Ipv6Addr) -> &mut Self {
+    pub fn set_local_ipv6(&self, ipv6: &Ipv6Addr) -> &Self {
         self.inner.set_local_ipv6(ipv6);
         self
     }
 
     /// Set the local device from which to make queries.
-    pub fn set_local_device(&mut self, device: &str) -> &mut Self {
+    pub fn set_local_device(&self, device: &str) -> &Self {
         self.inner.set_local_device(device);
         self
     }
@@ -377,7 +377,7 @@ impl FutureResolver {
     }
 
     /// Cancel all requests made on this `FutureResolver`.
-    pub fn cancel(&mut self) {
+    pub fn cancel(&self) {
         self.inner.cancel()
     }
 }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -124,7 +124,7 @@ impl Options {
 /// An asynchronous DNS resolver, which returns results via callbacks.
 pub struct Resolver {
     ares_channel: Arc<Mutex<c_ares::Channel>>,
-    event_loop_handle: Arc<Mutex<EventLoopHandle>>,
+    event_loop_handle: Arc<EventLoopHandle>,
 }
 
 // For each outstanding query, we want to make sure that the event-loop stays
@@ -166,7 +166,7 @@ impl Resolver {
         // Return the Resolver.
         let resolver = Resolver {
             ares_channel: channel,
-            event_loop_handle: Arc::new(Mutex::new(handle)),
+            event_loop_handle: Arc::new(handle),
         };
         Ok(resolver)
     }
@@ -177,27 +177,27 @@ impl Resolver {
     /// String format is `host[:port]`.  IPv6 addresses with ports require
     /// square brackets eg `[2001:4860:4860::8888]:53`.
     pub fn set_servers(
-        &mut self,
+        &self,
         servers: &[&str]
-    ) -> c_ares::Result<&mut Self> {
+    ) -> c_ares::Result<&Self> {
         self.ares_channel.lock().unwrap().set_servers(servers)?;
         Ok(self)
     }
 
     /// Set the local IPv4 address from which to make queries.
-    pub fn set_local_ipv4(&mut self, ipv4: &Ipv4Addr) -> &mut Self {
+    pub fn set_local_ipv4(&self, ipv4: &Ipv4Addr) -> &Self {
         self.ares_channel.lock().unwrap().set_local_ipv4(ipv4);
         self
     }
 
     /// Set the local IPv6 address from which to make queries.
-    pub fn set_local_ipv6(&mut self, ipv6: &Ipv6Addr) -> &mut Self {
+    pub fn set_local_ipv6(&self, ipv6: &Ipv6Addr) -> &Self {
         self.ares_channel.lock().unwrap().set_local_ipv6(ipv6);
         self
     }
 
     /// Set the local device from which to make queries.
-    pub fn set_local_device(&mut self, device: &str) -> &mut Self {
+    pub fn set_local_device(&self, device: &str) -> &Self {
         self.ares_channel.lock().unwrap().set_local_device(device);
         self
     }
@@ -468,7 +468,7 @@ impl Resolver {
     }
 
     /// Cancel all requests made on this `Resolver`.
-    pub fn cancel(&mut self) {
+    pub fn cancel(&self) {
         self.ares_channel.lock().unwrap().cancel();
     }
 }

--- a/src/unix/eventloop.rs
+++ b/src/unix/eventloop.rs
@@ -25,8 +25,6 @@ use eventloop::EventLoopHandle;
 //
 // -  events telling it that something has happened on one of these file
 //    descriptors.  When this happens, it tells the c_ares::Channel about it.
-//
-// -  a message telling it to shut down.
 pub struct EventLoop {
     poll: mio::Poll,
     rx_msg_channel: mio_more::channel::Receiver<Message>,

--- a/src/unix/eventloop.rs
+++ b/src/unix/eventloop.rs
@@ -3,6 +3,10 @@ use std::sync::{
     Arc,
     Mutex,
 };
+use std::sync::atomic::{
+    AtomicBool,
+    Ordering,
+};
 use std::thread;
 use std::time::Duration;
 
@@ -25,11 +29,10 @@ use eventloop::EventLoopHandle;
 // -  a message telling it to shut down.
 pub struct EventLoop {
     poll: mio::Poll,
-    tx_msg_channel: mio_more::channel::Sender<Message>,
     rx_msg_channel: mio_more::channel::Receiver<Message>,
     tracked_fds: HashSet<c_ares::Socket>,
     pub ares_channel: Arc<Mutex<c_ares::Channel>>,
-    quit: bool,
+    quit: Arc<AtomicBool>,
 }
 
 // Messages for the event loop.
@@ -40,9 +43,6 @@ pub enum Message {
     // allowed to set both of these - or neither, meaning 'I am no longer
     // interested in this file descriptor'.
     RegisterInterest(c_ares::Socket, bool, bool),
-
-    // 'Shut down'.
-    ShutDown,
 }
 
 // A token identifying that the message channel has become available for
@@ -68,10 +68,9 @@ impl EventLoop {
 
         // Whenever c-ares tells us what to do with a file descriptor, we'll
         // send that request along, through the channel we just created.
-        let tx_clone = tx.clone();
         let sock_callback =
             move |fd: c_ares::Socket, readable: bool, writable: bool| {
-                let _ = tx_clone.send(
+                let _ = tx.send(
                     Message::RegisterInterest(fd, readable, writable));
             };
         options.set_socket_state_callback(sock_callback);
@@ -83,20 +82,19 @@ impl EventLoop {
         // Create and return the event loop.
         let event_loop = EventLoop {
             poll: poll,
-            tx_msg_channel: tx,
             rx_msg_channel: rx,
             tracked_fds: HashSet::<c_ares::Socket>::new(),
             ares_channel: locked_channel,
-            quit: false,
+            quit: Arc::new(AtomicBool::new(false)),
         };
         Ok(event_loop)
     }
 
     // Run the event loop.
     pub fn run(self) -> EventLoopHandle {
-        let tx_clone = self.tx_msg_channel.clone();
+        let quit = Arc::clone(&self.quit);
         let join_handle = thread::spawn(|| self.event_loop_thread());
-        EventLoopHandle::new(join_handle, tx_clone)
+        EventLoopHandle::new(join_handle, quit)
     }
 
     // Event loop thread - waits for events, and handles them.
@@ -119,14 +117,13 @@ impl EventLoop {
                     );
                 },
                 _ => {
-                    // Process events.  One of them might have asked us to
-                    // quit.
+                    // Process events.
                     for event in &events {
                         self.handle_event(&event);
-                        if self.quit { return }
                     }
                 }
             }
+            if self.quit.load(Ordering::Relaxed) { break }
         }
     }
 
@@ -193,12 +190,6 @@ impl EventLoop {
                         };
                         register_result.expect("failed to register interest");
                     }
-                },
-
-                // Instruction to shut down.
-                Ok(Message::ShutDown) => {
-                    self.quit = true;
-                    break
                 },
 
                 // No more instructions.

--- a/src/windows/eventloop.rs
+++ b/src/windows/eventloop.rs
@@ -31,9 +31,6 @@ use eventloop::EventLoopHandle;
 
 // The EventLoop will use select() to check on the status of file descriptors
 // that c-ares cares about.
-//
-// It also waits for a message telling it to shut down.  We use a mio channel
-// here only for consistency with the unix interface.
 pub struct EventLoop {
     pub ares_channel: Arc<Mutex<c_ares::Channel>>,
     quit: Arc<AtomicBool>,

--- a/src/windows/eventloop.rs
+++ b/src/windows/eventloop.rs
@@ -64,7 +64,7 @@ impl EventLoop {
     }
 
     // Event loop thread - waits for events, and handles them.
-    fn event_loop_thread(mut self) {
+    fn event_loop_thread(self) {
         let mut read_fds: fd_set = unsafe { mem::uninitialized() };
         let mut write_fds: fd_set = unsafe { mem::uninitialized() };
 

--- a/src/windows/eventloop.rs
+++ b/src/windows/eventloop.rs
@@ -4,6 +4,10 @@ use std::sync::{
     Arc,
     Mutex,
 };
+use std::sync::atomic::{
+    AtomicBool,
+    Ordering,
+};
 use std::thread;
 use std::time::Duration;
 
@@ -31,17 +35,8 @@ use eventloop::EventLoopHandle;
 // It also waits for a message telling it to shut down.  We use a mio channel
 // here only for consistency with the unix interface.
 pub struct EventLoop {
-    tx_msg_channel: mio_more::channel::Sender<Message>,
-    rx_msg_channel: mio_more::channel::Receiver<Message>,
     pub ares_channel: Arc<Mutex<c_ares::Channel>>,
-    quit: bool,
-}
-
-// Messages for the event loop.
-#[derive(Debug)]
-pub enum Message {
-    // 'Shut down'.
-    ShutDown,
+    quit: Arc<AtomicBool>,
 }
 
 impl EventLoop {
@@ -53,19 +48,14 @@ impl EventLoop {
             WSAStartup(0x101, &mut wsadata);
         }
 
-        // Create the message channel.
-        let (tx, rx) = mio_more::channel::channel();
-
         // Create the c-ares channel.
         let ares_channel = c_ares::Channel::with_options(options)?;
         let locked_channel = Arc::new(Mutex::new(ares_channel));
 
         // Create and return the event loop.
         let event_loop = EventLoop {
-            tx_msg_channel: tx,
-            rx_msg_channel: rx,
             ares_channel: locked_channel,
-            quit: false,
+            quit: Arc::new(AtomicBool::new(false)),
         };
         Ok(event_loop)
     }
@@ -113,18 +103,7 @@ impl EventLoop {
                         .process(&mut read_fds, &mut write_fds),
                 }
             }
-
-            // Check whether we've been asked to quit.
-            self.handle_messages();
-            if self.quit { break }
-        }
-    }
-
-    // Process messages incoming on the channel.
-    fn handle_messages(&mut self) {
-        // The only possible message is an instruction to shut down.
-        if let Ok(Message::ShutDown) = self.rx_msg_channel.try_recv() {
-            self.quit = true;
+            if self.quit.load(Ordering::Relaxed) { break }
         }
     }
 }

--- a/src/windows/eventloop.rs
+++ b/src/windows/eventloop.rs
@@ -24,7 +24,6 @@ use ws2_32::{
 };
 
 use c_ares;
-use mio_more;
 
 use error::Error;
 use eventloop::EventLoopHandle;
@@ -59,9 +58,9 @@ impl EventLoop {
 
     // Run the event loop.
     pub fn run(self) -> EventLoopHandle {
-        let tx_clone = self.tx_msg_channel.clone();
+        let quit = Arc::clone(&self.quit);
         let join_handle = thread::spawn(|| self.event_loop_thread());
-        EventLoopHandle::new(join_handle, tx_clone)
+        EventLoopHandle::new(join_handle, quit)
     }
 
     // Event loop thread - waits for events, and handles them.


### PR DESCRIPTION
Fixes #4.

But is it the right thing to do?

* On the plus side, it's clearly a more convenient API if users don't have to worry about keeping resolvers alive while queries are pending
* Against this though: it's unnecessary cost for users who were perfectly willing to have a long-lived resolver all along.

Is this automatic keeping-things-alive stuff really in the spirit of rust-y zero-cost abstractions?  Could recommend that if this is what's wanted, users can achieve the desired result for themselves with a little more code eg wrap their resolver in an `Arc<RwLock<>>` and have their callbacks hold clones of that `Arc`.

But that's undeniably awkward...

I dunno.  I'll probably leave this open for a short period, while I mull over my indecision.