### PR TITLE
Keep the event loop alive while futures are unresolved

### DIFF
--- a/examples/futures.rs
+++ b/examples/futures.rs
@@ -1,11 +1,13 @@
 // This example demonstrates use of the `FutureResolver`.
 extern crate c_ares;
 extern crate c_ares_resolver;
+extern crate futures;
 extern crate tokio_core;
 
 use std::error::Error;
 
 use c_ares_resolver::FutureResolver;
+use futures::future::Future;
 
 fn print_mx_results(result: &Result<c_ares::MXResults, c_ares::Error>) {
     match *result {
@@ -27,12 +29,16 @@ fn print_mx_results(result: &Result<c_ares::MXResults, c_ares::Error>) {
 
 fn main() {
     // Create Resolver and make a query.
-    let resolver = FutureResolver::new().expect("Failed to create resolver");
-    let query = resolver.query_mx("gmail.com");
+    let query = {
+        let resolver = FutureResolver::new().expect("Failed to create resolver");
+        resolver.query_mx("gmail.com").then(|result| {
+            print_mx_results(&result);
+            result
+        })
+    };
 
     // Run the query to completion and print the results.
     let mut event_loop = tokio_core::reactor::Core::new()
         .expect("Failed to create event loop");
-    let result = event_loop.run(query);
-    print_mx_results(&result);
+    event_loop.run(query).ok();
 }


### PR DESCRIPTION
Fixes #4 

Unlike the previous try at #5, this one only affects the `FutureResolver`; dropping a `Resolver` still causes the underlying ares channel to be destroyed and all queries to be cancelled.

I think I like this better: the it treats the `Resolver` as a lower-level thing that can be built on for maximally efficient solutions for people who care about such things, while making the `FutureResolver` more convenient.

But I reckon I'll still sit on this for a short period of reflection before committing...