### PR TITLE
use channel from standard library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Drop crossbeam-channel in favour of standard library channels
+  - As of 1.67.0, the standard library's implementation is based on
+    crossbeam-channel
+
 ## 7.5.0 (29 Jan 2023)
 
 - Take upstream c-ares 1.19.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ include = ["src/**/*", "LICENSE.txt", "README.md", "CHANGELOG.md"]
 
 [dependencies]
 c-ares = "7.6.0"
-crossbeam-channel = "0.5.0"
 futures-channel = "0.3.9"
 polling = "2.0.1"
 


### PR DESCRIPTION
as of recent rust the implementation is based on crossbeam-channel, so no need to take the extra dependency.